### PR TITLE
Fixed fetching Artist tag

### DIFF
--- a/Me&tal Archives#Search by Album.src
+++ b/Me&tal Archives#Search by Album.src
@@ -112,9 +112,9 @@ sayuntil "</"
 
 # Artist
 outputto "Artist"
-findline "class=\"band_name\">"
+findline "<h2 class=\"band_name\">"
+moveline 1 1
 regexpreplace "<a[^>]+>" ""
-findinline "class=\"band_name\">"
 sayuntil "</"
 
 # Type

--- a/Me&tal Archives#Search by Band + Album.src
+++ b/Me&tal Archives#Search by Band + Album.src
@@ -111,9 +111,9 @@ sayuntil "</"
 
 # Artist
 outputto "Artist"
-findline "class=\"band_name\">"
+findline "<h2 class=\"band_name\">"
+moveline 1 1
 regexpreplace "<a[^>]+>" ""
-findinline "class=\"band_name\">"
 sayuntil "</"
 
 # Type

--- a/Me&tal Archives#Search by Band.src
+++ b/Me&tal Archives#Search by Band.src
@@ -112,9 +112,9 @@ sayuntil "</"
 
 # Artist
 outputto "Artist"
-findline "class=\"band_name\">"
+findline "<h2 class=\"band_name\">"
+moveline 1 1
 regexpreplace "<a[^>]+>" ""
-findinline "class=\"band_name\">"
 sayuntil "</"
 
 # Type


### PR DESCRIPTION
On Metal Archives, the Artist tag is on a different line instead on the same line as the album tag does. This was fixed by adding the moveline function under the findline. The other findline has being removed as the class isn't on that line.

Here's the HTML code from an album page on Metal Archives with the album and artist tag:
```
<div id="album_info">
--
<!-- Headers -->
<h1 class="album_name"><a href="https://www.metal-archives.com/albums/Thousand_Eyes/Day_of_Salvation/687854">Day of Salvation</a></h1>
<h2 class="band_name">
<a href="https://www.metal-archives.com/bands/Thousand_Eyes/3540362879">Thousand Eyes</a>
</h2>
 
<!-- Error / OK messages -->
```

