### PR TITLE
Split the search field into two (Band/Album)

### DIFF
--- a/Me&tal Archives#Search by Band + Album.src
+++ b/Me&tal Archives#Search by Band + Album.src
@@ -25,11 +25,11 @@
 
 [Name]=The Metal Archives
 [BasedOn]=www.metal-archives.com
-[IndexUrl]=http://www.metal-archives.com/search/ajax-advanced/searching/albums/?bandName=
+[IndexUrl]=http://www.metal-archives.com/search/ajax-advanced/searching/albums/?
 [AlbumUrl]=
 [WordSeperator]=+
 [IndexFormat]=%Artist%|%_url%|%Album%|%Type%
-[SearchBy]=%artist%&releaseTitle=%album%
+[SearchBy]=Band||%artist%||&bandName=%s||Album||%album%||&releaseTitle=%s
 [Encoding]=utf-8
 
 


### PR DESCRIPTION
Greetings, @antonio-gil 
First of all, thank you for making this repo!

With this PR, the search field for `Search by Band + Album` is split in two (Band/Album)

Comparison:

<details>
<summary>Before</summary>

![2020-03-18_234954](https://user-images.githubusercontent.com/723651/77010863-4f407000-6973-11ea-8b7d-12443149aeb0.jpg)
</details>

<details>
<summary>After</summary>

![2020-03-18_235007](https://user-images.githubusercontent.com/723651/77010871-536c8d80-6973-11ea-8a82-9e3295455e7e.jpg)
</details>